### PR TITLE
Replace `go get` commands with `go install`

### DIFF
--- a/searx-openbsd.html/0.md
+++ b/searx-openbsd.html/0.md
@@ -93,8 +93,8 @@ $ doas pip install gunicorn
 Install Filtron and Morty.
 
 ```
-$ go get github.com/asciimoo/filtron
-$ go get github.com/asciimoo/morty
+$ go install github.com/asciimoo/filtron@latest
+$ go install github.com/asciimoo/morty@latest
 $ doas ln -sf $HOME/go/bin/filtron /usr/local/bin/
 $ doas ln -sf $HOME/go/bin/morty /usr/local/bin/
 ```


### PR DESCRIPTION
go get command is deprecated, see https://go.dev/doc/go-get-install-deprecation

very cool website and content tho, love your OpenBSD posts. Appreciated!