### PR TITLE
Improve the e-mail server guide

### DIFF
--- a/mailserver-openbsd.html/0.md
+++ b/mailserver-openbsd.html/0.md
@@ -143,11 +143,11 @@ DNS records should look like this after following the steps above:
 
 | Type  | Name | Data             | TTL (seconds) | Priority |
 |-------|------|------------------|---------------|----------|
-| A     | mail |                  | 300           |          |
-| A     |      |                  | 300           |          |
-| AAAA  | mail |                  | 300           |          |
-| AAAA  |      |                  | 300           |          |
-| CAA   |      |0 iodef "mailto:caareport@example.com"| 300           |          |
+| A     | mail | \<IPv4-of-server>| 300           |          |
+| A     |      | \<IPv4-of-server>| 300           |          |
+| AAAA  | mail | \<IPv6-of-server>| 300           |          |
+| AAAA  |      | \<IPv6-of-server>| 300           |          |
+| CAA   |      | 0 issue "letsencrypt.org" | 300 |          |
 | CNAME | *    | example.com      | 300           |          |
 | MX    |      | mail.example.com | 300           | 0        |
 | MX    |      | example.com      | 300           | 10       |
@@ -548,6 +548,8 @@ service managesieve-login {
 }
 ```
 
+**Note**: Ensure that any adjustments related to SSL certificates in `/etc/dovecot/conf.d/10-ssl.conf` are commented out to prevent errors when starting the Dovecot daemon.
+
 Define a login class for Dovecot daemon, add following lines to **/etc/login.conf**:
 ```
 dovecot:\
@@ -592,10 +594,10 @@ DNS records should look like this after following the steps above:
 
 | Type  | Name | Data             | TTL (seconds) | Priority |
 |-------|------|------------------|---------------|----------|
-| A     | mail |                  | 300           |          |
-| A     |      |                  | 300           |          |
-| AAAA  | mail |                  | 300           |          |
-| AAAA  |      |                  | 300           |          |
+| A     | mail | \<IPv4-of-server>| 300           |          |
+| A     |      | \<IPv4-of-server>| 300           |          |
+| AAAA  | mail | \<IPv6-of-server>| 300           |          |
+| AAAA  |      | \<IPv6-of-server>| 300           |          |
 | CNAME | *    | example.com      | 300           |          |
 | MX    |      | mail.example.com | 300           | 0        |
 | MX    |      | example.com      | 300           | 10       |


### PR DESCRIPTION
**Changes:**

1. Add a note about the importance of commenting out settings related to SSL certificates in the `/etc/dovecot/conf.d/10-ssl.conf` file to avoid errors when starting the Dovecot daemon.
2. Improve the tables showing how DNS records should look like to make them clearer.