### PR TITLE
mailserver-openbsd: update required packages

### DIFF
--- a/mailserver-openbsd.html/0.md
+++ b/mailserver-openbsd.html/0.md
@@ -308,10 +308,10 @@ $ doas acme-client -v mail.example.com
 
 The mail server this article describes uses **OpenSMTPD** software for **MSA** and **MTA**. As a user management solution, this article shows creating virtual users.
 
-**OpenSMTPD** is present on the server. Install **opensmtpd-extras** for virtual users and credentials support.
+**OpenSMTPD** is present on the server. Install **opensmtpd-table-passwd** for virtual users and credentials support.
 
 ```
-$ doas pkg_add opensmtpd-extras opensmtpd-filter-rspamd
+$ doas pkg_add opensmtpd-table-passwd opensmtpd-filter-rspamd
 ```
 
 Keep present configuration as back-up.


### PR DESCRIPTION
Since version 7.6 of OpenBSD, the `opensmtpd-extras` package has been split into several packages named `opensmtpd-table-*`. In the case of this guide, the package now needed to get support for virtual users and credentials is `opensmtpd-table-passwd`.